### PR TITLE
xWindowsFeature: fails when feature not exist and Ensure Absent (#452)

### DIFF
--- a/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
+++ b/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
@@ -23,7 +23,7 @@ $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xWindowsFeature'
         If the specified role or feature does not contain any subfeatures then
         IncludeAllSubFeature will be set to $false. If the specified feature contains one
         or more subfeatures then IncludeAllSubFeature will be set to $true only if all the
-        subfeatures are installed. Otherwise, IncludeAllSubFeature will be set to $false. 
+        subfeatures are installed. Otherwise, IncludeAllSubFeature will be set to $false.
 #>
 function Get-TargetResource
 {
@@ -35,19 +35,19 @@ function Get-TargetResource
        [ValidateNotNullOrEmpty()]
        [String]
        $Name,
-       
+
        [ValidateNotNullOrEmpty()]
        [System.Management.Automation.PSCredential]
        [System.Management.Automation.Credential()]
        $Credential
     )
- 
+
     Write-Verbose -Message ($script:localizedData.GetTargetResourceStartMessage -f $Name)
-    
-    Import-ServerManager 
-    
+
+    Import-ServerManager
+
     Write-Verbose -Message ($script:localizedData.QueryFeature -f $Name)
-    
+
     $isWinServer2008R2SP1 = Test-IsWinServer2008R2SP1
     if ($isWinServer2008R2SP1 -and $PSBoundParameters.ContainsKey('Credential'))
     {
@@ -59,11 +59,11 @@ function Get-TargetResource
     {
         $feature = Get-WindowsFeature @PSBoundParameters
     }
-    
+
     Assert-SingleFeatureExists -Feature $feature -Name $Name
-    
+
     $includeAllSubFeature = $true
-    
+
     if ($feature.SubFeatures.Count -eq 0)
     {
         $includeAllSubFeature = $false
@@ -79,7 +79,7 @@ function Get-TargetResource
 
             if ($PSBoundParameters.ContainsKey('Credential'))
             {
-               $getWindowsFeatureParameters['Credential'] = $Credential 
+               $getWindowsFeatureParameters['Credential'] = $Credential
             }
 
             if ($isWinServer2008R2SP1 -and $PSBoundParameters.ContainsKey('Credential'))
@@ -97,9 +97,9 @@ function Get-TargetResource
             {
                 $subFeature = Get-WindowsFeature @getWindowsFeatureParameters
             }
-    
+
             Assert-SingleFeatureExists -Feature $subFeature -Name $currentSubFeatureName
-    
+
             if (-not $subFeature.Installed)
             {
                 $includeAllSubFeature = $false
@@ -118,7 +118,7 @@ function Get-TargetResource
     }
 
     Write-Verbose -Message ($script:localizedData.GetTargetResourceEndMessage -f $Name)
-    
+
     # Add all feature properties to the hash table
     return @{
         Name = $Name
@@ -131,7 +131,7 @@ function Get-TargetResource
 <#
     .SYNOPSIS
         Installs or uninstalls the role or feature with the given name on the target machine
-        with the option of installing or uninstalling all subfeatures as well. 
+        with the option of installing or uninstalling all subfeatures as well.
 
     .PARAMETER Name
         The name of the role or feature to install or uninstall.
@@ -198,7 +198,7 @@ function Set-TargetResource
 
         if ($PSBoundParameters.ContainsKey('LogPath'))
         {
-           $addWindowsFeatureParameters['LogPath'] = $LogPath 
+           $addWindowsFeatureParameters['LogPath'] = $LogPath
         }
 
         Write-Verbose -Message ($script:localizedData.InstallFeature -f $Name)
@@ -218,7 +218,7 @@ function Set-TargetResource
         {
             if ($PSBoundParameters.ContainsKey('Credential'))
             {
-               $addWindowsFeatureParameters['Credential'] = $Credential 
+               $addWindowsFeatureParameters['Credential'] = $Credential
             }
 
             $feature = Add-WindowsFeature @addWindowsFeatureParameters
@@ -249,7 +249,7 @@ function Set-TargetResource
 
         if ($PSBoundParameters.ContainsKey('LogPath'))
         {
-           $removeWindowsFeatureParameters['LogPath'] = $LogPath 
+           $removeWindowsFeatureParameters['LogPath'] = $LogPath
         }
 
         Write-Verbose -Message ($script:localizedData.UninstallFeature -f $Name)
@@ -269,7 +269,7 @@ function Set-TargetResource
         {
             if ($PSBoundParameters.ContainsKey('Credential'))
             {
-               $addWindowsFeatureParameters['Credential'] = $Credential 
+               $addWindowsFeatureParameters['Credential'] = $Credential
             }
 
             $feature = Remove-WindowsFeature @removeWindowsFeatureParameters
@@ -297,7 +297,7 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-        Tests if the role or feature with the given name is in the desired state. 
+        Tests if the role or feature with the given name is in the desired state.
 
     .PARAMETER Name
         The name of the role or feature to test the state of.
@@ -355,7 +355,7 @@ function Test-TargetResource
     )
 
     Write-Verbose -Message ($script:localizedData.TestTargetResourceStartMessage -f $Name)
-    
+
     Import-ServerManager
 
     $testTargetResourceResult = $false
@@ -366,11 +366,11 @@ function Test-TargetResource
 
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
-       $getWindowsFeatureParameters['Credential'] = $Credential 
+       $getWindowsFeatureParameters['Credential'] = $Credential
     }
-    
+
     Write-Verbose -Message ($script:localizedData.QueryFeature -f $Name)
-    
+
     $isWinServer2008R2SP1 = Test-IsWinServer2008R2SP1
     if ($isWinServer2008R2SP1 -and $PSBoundParameters.ContainsKey('Credential'))
     {
@@ -387,62 +387,79 @@ function Test-TargetResource
     {
         $feature = Get-WindowsFeature @getWindowsFeatureParameters
     }
-    
-    Assert-SingleFeatureExists -Feature $feature -Name $Name
-    
-    # Check if the feature is in the requested Ensure state.
-    if (($Ensure -eq 'Present' -and $feature.Installed -eq $true) -or `
-        ($Ensure -eq 'Absent' -and $feature.Installed -eq $false))
+
+    # Multiple instances of feature exists
+    if ($feature.Count -gt 1)
+    {
+        New-InvalidOperationException -Message ($script:localizedData.MultipleFeatureInstancesError -f $Name)
+    }
+    # Check that feature exists if it is requested to be Present
+    elseif ($null -eq $feature -and $Ensure -eq 'Present')
+    {
+        New-InvalidOperationException -Message ($script:localizedData.FeatureNotFoundError -f $Name)
+    }
+    # The feature not existing is fine if it is requested to be absent
+    elseif ($null -eq $feature -and $Ensure -eq 'Absent')
     {
         $testTargetResourceResult = $true
-    
-        if ($IncludeAllSubFeature)
+    }
+    # Check that feature is installed if it is requested to be Present
+    elseif ($feature.Installed -and $Ensure -eq 'Present')
+    {
+        $testTargetResourceResult = $true
+    }
+    # Check that feature is installed if it is requested to be Absent
+    elseif (-not $feature.Installed -and $Ensure -eq 'Absent')
+    {
+        $testTargetResourceResult = $true
+    }
+    # Ensure is not in the correct state
+    else
+    {
+        $testTargetResourceResult = $false
+    }
+
+    if ($testTargetResourceResult -and $IncludeAllSubFeature)
+    {
+        # Check if each subfeature is in the requested state.
+        foreach ($currentSubFeatureName in $feature.SubFeatures)
         {
-            # Check if each subfeature is in the requested state.
-            foreach ($currentSubFeatureName in $feature.SubFeatures)
+            $getWindowsFeatureParameters['Name'] = $currentSubFeatureName
+
+            if ($isWinServer2008R2SP1 -and $PSBoundParameters.ContainsKey('Credential'))
             {
-                $getWindowsFeatureParameters['Name'] = $currentSubFeatureName
-    
-                if ($isWinServer2008R2SP1 -and $PSBoundParameters.ContainsKey('Credential'))
-                {
-                    <#
-                        Calling Get-WindowsFeature through Invoke-Command to start a new process with
-                        the given credential since Get-WindowsFeature doesn't support the Credential
-                        attribute on this server.
-                    #>
-                    $subFeature = Invoke-Command -ScriptBlock { Get-WindowsFeature -Name $currentSubFeatureName } `
-                                                 -ComputerName . `
-                                                 -Credential $Credential
-                }
-                else
-                {
-                    $subFeature = Get-WindowsFeature @getWindowsFeatureParameters
-                }
-                
-                Assert-SingleFeatureExists -Feature $subFeature -Name $currentSubFeatureName
-    
-                if (-not $subFeature.Installed -and $Ensure -eq 'Present')
-                {
-                    $testTargetResourceResult = $false
-                    break
-                }
-    
-                if ($subFeature.Installed -and $Ensure -eq 'Absent')
-                {
-                    $testTargetResourceResult = $false
-                    break
-                }
+                <#
+                    Calling Get-WindowsFeature through Invoke-Command to start a new process with
+                    the given credential since Get-WindowsFeature doesn't support the Credential
+                    attribute on this server.
+                #>
+                $subFeature = Invoke-Command -ScriptBlock { Get-WindowsFeature -Name $currentSubFeatureName } `
+                                                -ComputerName . `
+                                                -Credential $Credential
+            }
+            else
+            {
+                $subFeature = Get-WindowsFeature @getWindowsFeatureParameters
+            }
+
+            Assert-SingleFeatureExists -Feature $subFeature -Name $currentSubFeatureName
+
+            if (-not $subFeature.Installed -and $Ensure -eq 'Present')
+            {
+                $testTargetResourceResult = $false
+                break
+            }
+
+            if ($subFeature.Installed -and $Ensure -eq 'Absent')
+            {
+                $testTargetResourceResult = $false
+                break
             }
         }
     }
-    else
-    {
-        # Ensure is not in the correct state
-        $testTargetResourceResult = $false
-    }
-    
+
     Write-Verbose -Message ($script:localizedData.TestTargetResourceEndMessage -f $Name)
-    
+
     return $testTargetResourceResult
 }
 
@@ -456,7 +473,7 @@ function Test-TargetResource
 
     .PARAMETER Name
         The name of the role or feature to include in any error messages that are thrown.
-        (Not used to assert validity of the feature).    
+        (Not used to assert validity of the feature).
 #>
 function Assert-SingleFeatureExists
 {
@@ -488,7 +505,7 @@ function Assert-SingleFeatureExists
 #>
 function Import-ServerManager
 {
-    param 
+    param
     ()
 
     <#
@@ -538,7 +555,7 @@ function Import-ServerManager
 <#
     .SYNOPSIS
         Tests if the machine is a Windows Server 2008 R2 SP1 machine.
-    
+
     .NOTES
         Since Assert-PrequisitesValid ensures that ServerManager is available on the machine,
         this function only checks the OS version.

--- a/README.md
+++ b/README.md
@@ -714,6 +714,9 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 
 ### Unreleased
 
+* Changes to xWindowsFeature
+  * Fixed an issue where Test-TargetResource fails when feature is not installed and Ensure is set to Absent ([issue #452](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/452))
+
 ### 8.5.0.0
 * Changes to xRegistry
   * Fixed an issue that fails to remove reg key when the `Key` is specified as common registry path. ([issue #444](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/444))

--- a/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
@@ -21,18 +21,19 @@ try {
 
         $testWindowsFeatureName1 = 'Test1'
         $testWindowsFeatureName2 = 'Test2'
+        $testWindowsFeatureName3 = 'Test3'
         $testSubFeatureName1 = 'SubTest1'
         $testSubFeatureName2 = 'SubTest2'
         $testSubFeatureName3 = 'SubTest3'
 
 
         $mockWindowsFeatures = @{
-            Test1 = @{ 
+            Test1 = @{
                 Name                      = 'Test1'
                 DisplayName               = 'Test Feature 1'
                 Description               = 'Test Feature with 3 subfeatures'
-                Installed                 = $false 
-                InstallState              = 'Available' 
+                Installed                 = $false
+                InstallState              = 'Available'
                 FeatureType               = 'Role Service'
                 Path                      = 'Test1'
                 Depth                     = 1
@@ -48,7 +49,7 @@ try {
                 AdditionalInfo            = @('MajorVersion', 'MinorVersion', 'NumericId', 'InstallName')
             }
 
-            SubTest1 = @{ 
+            SubTest1 = @{
                 Name                      = 'SubTest1'
                 DisplayName               = 'Sub Test Feature 1'
                 Description               = 'Sub Test Feature with parent as test1'
@@ -69,7 +70,7 @@ try {
                 AdditionalInfo            = @('MajorVersion', 'MinorVersion', 'NumericId', 'InstallName')
             }
 
-            SubTest2 = @{ 
+            SubTest2 = @{
                 Name                      = 'SubTest2'
                 DisplayName               = 'Sub Test Feature 2'
                 Description               = 'Sub Test Feature with parent as test1'
@@ -111,12 +112,12 @@ try {
                 AdditionalInfo            = @('MajorVersion', 'MinorVersion', 'NumericId', 'InstallName')
             }
 
-            Test2 = @{ 
+            Test2 = @{
                 Name                      = 'Test2'
                 DisplayName               = 'Test Feature 2'
                 Description               = 'Test Feature with 0 subfeatures'
-                Installed                 = $true 
-                InstallState              = 'Available' 
+                Installed                 = $true
+                InstallState              = 'Available'
                 FeatureType               = 'Role Service'
                 Path                      = 'Test2'
                 Depth                     = 1
@@ -141,7 +142,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testWindowsFeatureName2]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -149,7 +150,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testWindowsFeatureName1]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -157,7 +158,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testSubFeatureName1]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -165,7 +166,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testSubFeatureName2]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -173,13 +174,13 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testSubFeatureName3]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
-            
+
 
             Context 'Windows Feature exists with no sub features' {
-              
+
                 It 'Should return the correct hashtable when not on a 2008 Server' {
                     Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $false }
 
@@ -202,11 +203,11 @@ try {
 
                 It 'Should return the correct hashtable when on a 2008 Server and Credential is passed' {
                     Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $true }
-                    Mock -CommandName Invoke-Command -MockWith { 
+                    Mock -CommandName Invoke-Command -MockWith {
                         $windowsFeature = $mockWindowsFeatures[$testWindowsFeatureName2]
                         $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                         $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                         return $windowsFeatureObject
                     }
 
@@ -259,7 +260,7 @@ try {
                 }
             }
         }
-        
+
         Describe 'xWindowsFeature/Set-TargetResource' {
             Mock -CommandName Import-ServerManager -MockWith {}
 
@@ -275,7 +276,7 @@ try {
                     }
                     $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                     $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                     return $windowsFeatureObject
                 }
 
@@ -288,7 +289,7 @@ try {
                     }
                     $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                     $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                     return $windowsFeatureObject
                 }
 
@@ -316,7 +317,7 @@ try {
                     }
                     $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                     $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                     return $windowsFeatureObject
                 }
 
@@ -329,18 +330,18 @@ try {
                     }
                     $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                     $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                     return $windowsFeatureObject
                 }
 
                 It 'Should throw invalid operation exception when Ensure set to Present' {
-                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Present' } | 
+                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Present' } |
                         Should Throw ($script:localizedData.FeatureInstallationFailureError -f $testWindowsFeatureName2)
                     Assert-MockCalled -CommandName Add-WindowsFeature -Times 1 -Exactly -Scope It
                 }
 
                 It 'Should throw invalid operation exception when Ensure set to Absent' {
-                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Absent' } | 
+                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Absent' } |
                         Should Throw ($script:localizedData.FeatureUninstallationFailureError -f $testWindowsFeatureName2)
                     Assert-MockCalled -CommandName Remove-WindowsFeature -Times 1 -Exactly -Scope It
                 }
@@ -359,7 +360,7 @@ try {
                     }
                     $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                     $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                     return $windowsFeatureObject
                 }
 
@@ -368,7 +369,7 @@ try {
 
                 It 'Should install the feature when Ensure set to Present and Credential passed in' {
 
-                    { 
+                    {
                         Set-TargetResource -Name $testWindowsFeatureName2 `
                                            -Ensure 'Present' `
                                            -Credential $testCredential
@@ -379,7 +380,7 @@ try {
 
                 It 'Should uninstall the feature when Ensure set to Absent and Credential passed in' {
 
-                    { 
+                    {
                         Set-TargetResource -Name $testWindowsFeatureName2 `
                                            -Ensure 'Absent' `
                                            -Credential $testCredential
@@ -397,7 +398,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testWindowsFeatureName1]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -405,7 +406,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testSubFeatureName1]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -413,7 +414,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testSubFeatureName2]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -421,7 +422,7 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testSubFeatureName3]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
@@ -430,11 +431,21 @@ try {
                 $windowsFeature = $mockWindowsFeatures[$testWindowsFeatureName1]
                 $windowsFeatureObject = New-Object -TypeName PSObject -Property $windowsFeature
                 $windowsFeatureObject.PSTypeNames[0] = 'Microsoft.Windows.ServerManager.Commands.Feature'
-            
+
                 return $windowsFeatureObject
             }
 
             Context 'Feature is in the desired state' {
+
+                It 'Should return true when Ensure set to Absent and Feature does not exist' {
+                    Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $false }
+
+                    $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName3 `
+                                                  -Ensure 'Absent' `
+                                                  -IncludeAllSubFeature $false
+                    $testTargetResourceResult | Should Be $true
+                    Assert-MockCalled -CommandName Get-WindowsFeature -Times 1 -Exactly -Scope It
+                }
 
                 It 'Should return true when Ensure set to Absent and Feature not installed' {
                     Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $false }
@@ -584,14 +595,14 @@ try {
                 Mock -CommandName Import-Module -MockWith {}
                 { Import-ServerManager } | Should Not Throw
             }
-            
+
             It 'Should Not Throw when exception is Identity Reference Runtime Exception' {
                 $mockIdentityReferenceRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Some or all identity references could not be translated'
                 Mock -CommandName Import-Module -MockWith { Throw $mockIdentityReferenceRuntimeException }
 
                 { Import-ServerManager } | Should Not Throw
             }
-            
+
             It 'Should throw invalid operation exception when exception is not Identity Reference Runtime Exception' {
                 $mockOtherRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Other error'
                 Mock -CommandName Import-Module -MockWith { Throw $mockOtherRuntimeException }


### PR DESCRIPTION
#### Pull Request (PR) description
Prevents xWindowsFeature from failing when Ensure Absent and the feature does not exist.

#### This Pull Request (PR) fixes the following issues
    - Fixes #452

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
